### PR TITLE
Descriptive error messages

### DIFF
--- a/src/Dialogue/DialogueManager.cpp
+++ b/src/Dialogue/DialogueManager.cpp
@@ -59,7 +59,7 @@ namespace DDR
 				}
 				responses++;
 			} catch (std::exception& e) {
-				logger::info("Failed to load response replaccement - {}", e.what());
+				logger::info("Line {}: Failed to load response replacement - {}", it.Mark().line, e.what());
 			}
 		}
 		return responses;
@@ -78,7 +78,7 @@ namespace DDR
 				_topicReplacements[repl->GetId()].emplace_back(repl);
 				topics++;
 			} catch (std::exception& e) {
-				logger::info("Failed to load topic replacement - {}", e.what());
+				logger::info("Line {}: Failed to load topic replacement - {}", it.Mark().line, e.what());
 			}
 		}
 		return topics;
@@ -95,12 +95,12 @@ namespace DDR
 			try {
 				TextReplacement repl{ it };
 				if (!_lua.InitializeEnvironment(repl)) {
-					logger::info("Failed to initialize environment for script {}", repl.GetScript());
+					logger::info("Line {}: Failed to initialize environment for script {}", it.Mark().line, repl.GetScript());
 				} else {
 					scripts++;
 				}
 			} catch (std::exception& e) {
-				logger::info("Failed to load script - {}", e.what());
+				logger::info("Line {}: Failed to load script - {}", it.Mark().line, e.what());
 			}
 		}
 		return scripts;

--- a/src/Dialogue/Topic.cpp
+++ b/src/Dialogue/Topic.cpp
@@ -19,24 +19,29 @@ namespace DDR
 	{
 		if (!_affectedTopic || !RE::TESForm::LookupByID<RE::TESTopic>(_affectedTopic)) {
 			const YAML::Node& errored_node = a_node["id"];
-			throw std::runtime_error(std::format("Line {}:{}: Failed to obtain id topic '{}'", errored_node.Mark().line, errored_node.Mark().column, errored_node.as<std::string>()));
+			const auto err = std::format("Line {}:{}: Failed to obtain id topic '{}'", errored_node.Mark().line, errored_node.Mark().column, errored_node.as<std::string>());
+			throw std::runtime_error(err);
 		}
 		if (_affectedInfo && !RE::TESForm::LookupByID<RE::TESTopic>(_affectedInfo)) {
 			const YAML::Node& errored_node = a_node["affects"];
-			throw std::runtime_error(std::format("Line {}:{}: Failed to obtain affected topic '{}'. Did you state a TopicInfo ID instead of a Topic ID?", errored_node.Mark().line, errored_node.Mark().column, errored_node.as<std::string>()));
+			const auto err = std::format("Line {}:{}: Failed to obtain affected topic '{}'. Did you state a TopicInfo ID instead of a Topic ID?", errored_node.Mark().line, errored_node.Mark().column, errored_node.as<std::string>());
+			throw std::runtime_error(err);
 		}
 		if (_replaceWith) {
 			if (!RE::TESForm::LookupByID<RE::TESTopic>(_replaceWith)) {
 				const YAML::Node& errored_node = a_node["replace"];
-				throw std::runtime_error(std::format("Line {}:{}: Failed to obtain replacement topic '{}'", errored_node.Mark().line, errored_node.Mark().column, errored_node.as<std::string>()));
+				const auto err = std::format("Line {}:{}: Failed to obtain replacement topic '{}'", errored_node.Mark().line, errored_node.Mark().column, errored_node.as<std::string>());
+				throw std::runtime_error(err);
 			} else if (!_affectedInfo) {
 				const YAML::Node& errored_node = a_node;
-				throw std::runtime_error(std::format("Line {}:{}: Missing affected topic. Replacement must specify affected info topic when replacing topic", errored_node.Mark().line, errored_node.Mark().column));
+				const auto err = std::format("Line {}:{}: Missing affected topic. Replacement must specify affected info topic when replacing topic", errored_node.Mark().line, errored_node.Mark().column);
+				throw std::runtime_error(err);
 			} 
 		}
 		if (_text.empty() && !_replaceWith && _inject.empty() && !_hide) {
 			const YAML::Node& errored_node = a_node;
-			throw std::runtime_error(std::format("Line {}:{}: Failed to find text or with/inject topics in replacement", errored_node.Mark().line, errored_node.Mark().column));
+			const auto err = std::format("Line {}:{}: Failed to find text or with/inject topics in replacement", errored_node.Mark().line, errored_node.Mark().column);
+			throw std::runtime_error(err);
 		}
 	}
 

--- a/src/Dialogue/Topic.cpp
+++ b/src/Dialogue/Topic.cpp
@@ -18,20 +18,25 @@ namespace DDR
 		_hide(a_node["hide"].as<std::string>("") == "true" || a_node["hide"].as<bool>(false))
 	{
 		if (!_affectedTopic || !RE::TESForm::LookupByID<RE::TESTopic>(_affectedTopic)) {
-			throw std::runtime_error("Failed to obtain affected topic");
+			const YAML::Node& errored_node = a_node["id"];
+			throw std::runtime_error(std::format("Line {}:{}: Failed to obtain id topic '{}'", errored_node.Mark().line, errored_node.Mark().column, errored_node.as<std::string>()));
 		}
 		if (_affectedInfo && !RE::TESForm::LookupByID<RE::TESTopic>(_affectedInfo)) {
-			throw std::runtime_error("Failed to obtain affected info topic. Did you state a TopicInfo ID instead of a Topic ID?");
+			const YAML::Node& errored_node = a_node["affects"];
+			throw std::runtime_error(std::format("Line {}:{}: Failed to obtain affected topic '{}'. Did you state a TopicInfo ID instead of a Topic ID?", errored_node.Mark().line, errored_node.Mark().column, errored_node.as<std::string>()));
 		}
 		if (_replaceWith) {
 			if (!RE::TESForm::LookupByID<RE::TESTopic>(_replaceWith)) {
-				throw std::runtime_error("Failed to obtain replacement topic");
+				const YAML::Node& errored_node = a_node["replace"];
+				throw std::runtime_error(std::format("Line {}:{}: Failed to obtain replacement topic '{}'", errored_node.Mark().line, errored_node.Mark().column, errored_node.as<std::string>()));
 			} else if (!_affectedInfo) {
-				throw std::runtime_error("Missing affected info topic. Replacement must specify affected info topic when replacing topic");
+				const YAML::Node& errored_node = a_node;
+				throw std::runtime_error(std::format("Line {}:{}: Missing affected topic. Replacement must specify affected info topic when replacing topic", errored_node.Mark().line, errored_node.Mark().column));
 			} 
 		}
 		if (_text.empty() && !_replaceWith && _inject.empty() && !_hide) {
-			throw std::runtime_error("Failed to find text or with/inject topics in replacement");
+			const YAML::Node& errored_node = a_node;
+			throw std::runtime_error(std::format("Line {}:{}: Failed to find text or with/inject topics in replacement", errored_node.Mark().line, errored_node.Mark().column));
 		}
 	}
 

--- a/src/Dialogue/Topic.cpp
+++ b/src/Dialogue/Topic.cpp
@@ -25,7 +25,7 @@ namespace DDR
 		}
 		if (_replaceWith) {
 			if (!RE::TESForm::LookupByID<RE::TESTopic>(_replaceWith)) {
-				throw std::runtime_error("Failed to obtain replacement topic '{}'");
+				throw std::runtime_error("Failed to obtain replacement topic");
 			} else if (!_affectedInfo) {
 				throw std::runtime_error("Missing affected topic. Replacement must specify affected info topic when replacing topic");
 			} 

--- a/src/Dialogue/Topic.cpp
+++ b/src/Dialogue/Topic.cpp
@@ -18,30 +18,20 @@ namespace DDR
 		_hide(a_node["hide"].as<std::string>("") == "true" || a_node["hide"].as<bool>(false))
 	{
 		if (!_affectedTopic || !RE::TESForm::LookupByID<RE::TESTopic>(_affectedTopic)) {
-			const YAML::Node& errored_node = a_node["id"];
-			const auto err = std::format("Line {}:{}: Failed to obtain id topic '{}'", errored_node.Mark().line, errored_node.Mark().column, errored_node.as<std::string>());
-			throw std::runtime_error(err);
+			throw std::runtime_error("Failed to obtain id topic");
 		}
 		if (_affectedInfo && !RE::TESForm::LookupByID<RE::TESTopic>(_affectedInfo)) {
-			const YAML::Node& errored_node = a_node["affects"];
-			const auto err = std::format("Line {}:{}: Failed to obtain affected topic '{}'. Did you state a TopicInfo ID instead of a Topic ID?", errored_node.Mark().line, errored_node.Mark().column, errored_node.as<std::string>());
-			throw std::runtime_error(err);
+			throw std::runtime_error("Failed to obtain affected topic. Did you state a TopicInfo ID instead of a Topic ID?");
 		}
 		if (_replaceWith) {
 			if (!RE::TESForm::LookupByID<RE::TESTopic>(_replaceWith)) {
-				const YAML::Node& errored_node = a_node["replace"];
-				const auto err = std::format("Line {}:{}: Failed to obtain replacement topic '{}'", errored_node.Mark().line, errored_node.Mark().column, errored_node.as<std::string>());
-				throw std::runtime_error(err);
+				throw std::runtime_error("Failed to obtain replacement topic '{}'");
 			} else if (!_affectedInfo) {
-				const YAML::Node& errored_node = a_node;
-				const auto err = std::format("Line {}:{}: Missing affected topic. Replacement must specify affected info topic when replacing topic", errored_node.Mark().line, errored_node.Mark().column);
-				throw std::runtime_error(err);
+				throw std::runtime_error("Missing affected topic. Replacement must specify affected info topic when replacing topic");
 			} 
 		}
 		if (_text.empty() && !_replaceWith && _inject.empty() && !_hide) {
-			const YAML::Node& errored_node = a_node;
-			const auto err = std::format("Line {}:{}: Failed to find text or with/inject topics in replacement", errored_node.Mark().line, errored_node.Mark().column);
-			throw std::runtime_error(err);
+			throw std::runtime_error("Failed to find text or replace/inject topics in replacement");
 		}
 	}
 


### PR DESCRIPTION
Error messages previously didn't show anything about the location of the error, which makes pinpointing the error difficult in large dialogue replacement files.

## What this PR does:
1. adds the line number of the relevant YAML node in error messages
2. replaces "info topic" by "topic" in error messages ("info topic" appears e.g. [here](https://github.com/Scrabx3/Dynamic-Dialogue-Replacer/blob/2d6fd6118d355841c58433b2b892b59c957a17de/src/Dialogue/Topic.cpp#L24) and at line 30). I am unsure what "info topic" is supposed to mean.
## What it doesn't do (yet?):
1. Details errors related to FormID parsing, i.e. which FormID string failed to be parsed or to be found.

File name is not exposed in the functions I tapped in, so only line number and column can be shown. In most cases, mods use a single replacement file, and in any case, the file name is already printed to log at the end of its parsing.

This PR does not change any logic. In particular, [here](https://github.com/Scrabx3/Dynamic-Dialogue-Replacer/blob/2d6fd6118d355841c58433b2b892b59c957a17de/src/Dialogue/Topic.cpp#L33) the condition `&& !_replaceWith &&` should probably be removed, but being unsure what this error case really means, I left it unchanged.
I am also unsure why the member variable `Topic::_affectedInfo` is called what is it, when it does not reference a topic info, but a topic.


## Example log line before/after:
`[16:15:53.966] [17132] [I] Failed to load topic replacement - Failed to obtain replacement topic`
`[16:15:53.966] [17132] [I] Line 55: Failed to load topic replacement - Failed to obtain replacement topic`

--- 
Requests for changes are welcome.