### PR TITLE
Fix RefMap loading & logging tweaks

### DIFF
--- a/src/Dialogue/Conditions/ConditionParser.cpp
+++ b/src/Dialogue/Conditions/ConditionParser.cpp
@@ -80,7 +80,7 @@ RE::TESConditionItem* ConditionParser::Parse(std::string_view a_text, const RefM
 
 	if (mComparand.matched) {
 		auto comparand = mComparand.str();
-		if (auto global = RE::TESForm::LookupByEditorID<RE::TESGlobal>(comparand)) {
+		if (auto global = a_refMap.Lookup<RE::TESGlobal>(comparand)) {
 			data.comparisonValue.g = global;
 			data.flags.global = true;
 		} else {

--- a/src/Dialogue/Conditions/ConditionParser.cpp
+++ b/src/Dialogue/Conditions/ConditionParser.cpp
@@ -102,7 +102,7 @@ RE::TESConditionItem* ConditionParser::Parse(std::string_view a_text, const RefM
 			data.runOnRef = ref->CreateRefHandle();
 			data.object = RE::CONDITIONITEMOBJECT::kRef;
 		} else {
-			logger::info("failed to find ref {}", refStr);
+			throw std::runtime_error(std::format("Failed to parse subject form: {}", refStr));
 		}
 	}
 
@@ -160,7 +160,7 @@ ConditionParser::ConditionParam ConditionParser::ParseParam(const std::string& a
 		param.str = new RE::BSString(a_text.c_str());
 		break;
 	default:
-		param.form = a_refMap.Lookup(textCIS);
+		param.form = a_refMap.Lookup(a_text);
 		break;
 	}
 	return param;

--- a/src/Dialogue/Conditions/RefMap.h
+++ b/src/Dialogue/Conditions/RefMap.h
@@ -51,10 +51,15 @@ namespace Conditions
 	public:
 		RefMap(const std::map<std::string, std::string>& a_rawRefs)
 		{
+			if (a_rawRefs.size() > 0) {
+				logger::info("Loading reference map ({} raw entries)", a_rawRefs.size());
+			}
 			refMap["player"] = RE::PlayerCharacter::GetSingleton();
 			for (const auto& [key, refStr] : a_rawRefs) {
 				if (auto ref = Lookup<RE::TESForm>(refStr)) {
 					refMap[key] = ref;
+				} else {
+					logger::error("Failed to validate RefMap value: '{}'. Entry ignored.", refStr);
 				}
 			}
 		}

--- a/src/Dialogue/Conditions/RefMap.h
+++ b/src/Dialogue/Conditions/RefMap.h
@@ -27,17 +27,13 @@ namespace Conditions
 			auto ref = Util::FormFromString<T>(a_key);
 			if (!ref) {
 				ref = RE::TESForm::LookupByEditorID<T>(a_key);
-				if (!ref) {
-					logger::error("Failed to lookup form for key: {}", a_key);
-					return nullptr;
-				}
 			}
 			return ref;
 		}
 
 		RE::FormID LookupId(const std::string& a_key) const
 		{
-			if (a_key.empty()) {
+			if (a_key.empty() or a_key == "0"s) {
 				return 0;
 			}
 			const auto ref = Lookup(a_key);

--- a/src/Dialogue/Conditions/RefMap.h
+++ b/src/Dialogue/Conditions/RefMap.h
@@ -20,9 +20,6 @@ namespace Conditions
 		template <typename T = RE::TESForm>
 		T* Lookup(const std::string& a_key) const
 		{
-			if (a_key.empty()) {
-				return nullptr;
-			}
 			if (refMap.contains(a_key)) {
 				const auto ret = refMap.at(a_key);
 				return ret->As<T>();
@@ -40,6 +37,9 @@ namespace Conditions
 
 		RE::FormID LookupId(const std::string& a_key) const
 		{
+			if (a_key.empty()) {
+				return 0;
+			}
 			const auto ref = Lookup(a_key);
 			if (ref) {
 				return ref->GetFormID();

--- a/src/Dialogue/Conditions/RefMap.h
+++ b/src/Dialogue/Conditions/RefMap.h
@@ -49,7 +49,7 @@ namespace Conditions
 		}
 
 	public:
-		RefMap(const std::vector<std::pair<std::string, std::string>>& a_rawRefs)
+		RefMap(const std::map<std::string, std::string>& a_rawRefs)
 		{
 			refMap["player"] = RE::PlayerCharacter::GetSingleton();
 			for (const auto& [key, refStr] : a_rawRefs) {

--- a/src/Dialogue/DialogueManager.cpp
+++ b/src/Dialogue/DialogueManager.cpp
@@ -22,6 +22,7 @@ namespace DDR
 			}
 			const std::string fileName = entry.path().string();
 			try {
+				logger::info("Loading file {}", fileName);
 				const auto file = YAML::LoadFile(fileName);
 				const auto refs = file["refMap"].as<std::map<std::string, std::string>>(std::map<std::string, std::string>{});
 				const Conditions::RefMap refMap{ refs };
@@ -49,6 +50,7 @@ namespace DDR
 		if (!node.IsDefined() || !node.IsSequence()) {
 			return 0;
 		}
+		logger::info("Loading TopicInfo replacements");
 		size_t responses = 0;
 		for (const auto&& it : node) {
 			try {
@@ -70,6 +72,7 @@ namespace DDR
 		if (!node.IsDefined() || !node.IsSequence()) {
 			return 0;
 		}
+		logger::info("Loading Topic replacements");
 		size_t topics = 0;
 		for (const auto&& it : node) {
 			try {

--- a/src/Dialogue/DialogueManager.cpp
+++ b/src/Dialogue/DialogueManager.cpp
@@ -180,7 +180,7 @@ namespace DDR
 			for (const auto& repl : replacements) {
 				if (a_preprocessing && !repl->HasPreProcessingAction())
 					continue;
-				if (repl->ConditionsMet(player, a_target)) {
+				if (repl->ConditionsMet(a_target, player)) {
 					ret.push_back(repl);
 				}
 			}

--- a/src/Dialogue/DialogueManager.cpp
+++ b/src/Dialogue/DialogueManager.cpp
@@ -23,7 +23,7 @@ namespace DDR
 			const std::string fileName = entry.path().string();
 			try {
 				const auto file = YAML::LoadFile(fileName);
-				const auto refs = file["refs"].as<std::vector<std::pair<std::string, std::string>>>(std::vector<std::pair<std::string, std::string>>{});
+				const auto refs = file["refMap"].as<std::map<std::string, std::string>>(std::map<std::string, std::string>{});
 				const Conditions::RefMap refMap{ refs };
 				size_t responses = ParseResponses(file, refMap);
 				size_t topics = ParseTopics(file, refMap);

--- a/src/Dialogue/DialogueManager.cpp
+++ b/src/Dialogue/DialogueManager.cpp
@@ -58,7 +58,7 @@ namespace DDR
 				}
 				responses++;
 			} catch (std::exception& e) {
-				logger::info("Line {}: Failed to load response replacement - {}", it.Mark().line, e.what());
+				logger::info("Line {}: Failed to load response replacement - {}", 1 + it.Mark().line, e.what());
 			}
 		}
 		return responses;
@@ -81,7 +81,7 @@ namespace DDR
 				}
 				topics++;
 			} catch (std::exception& e) {
-				logger::info("Line {}: Failed to load topic replacement - {}", it.Mark().line, e.what());
+				logger::info("Line {}: Failed to load topic replacement - {}", 1 + it.Mark().line, e.what());
 			}
 		}
 		return topics;
@@ -98,12 +98,12 @@ namespace DDR
 			try {
 				TextReplacement repl{ it };
 				if (!_lua.InitializeEnvironment(repl)) {
-					logger::info("Line {}: Failed to initialize environment for script {}", it.Mark().line, repl.GetScript());
+					logger::info("Line {}: Failed to initialize environment for script {}", 1 + it.Mark().line, repl.GetScript());
 				} else {
 					scripts++;
 				}
 			} catch (std::exception& e) {
-				logger::info("Line {}: Failed to load script - {}", it.Mark().line, e.what());
+				logger::info("Line {}: Failed to load script - {}", 1 + it.Mark().line, e.what());
 			}
 		}
 		return scripts;

--- a/src/Hooks/Hooks.cpp
+++ b/src/Hooks/Hooks.cpp
@@ -36,7 +36,7 @@ namespace DDR
 
 		DialogueMenuEx::Install();
 
-		logger::info("installed hooks");
+		logger::info("Installed hooks");
 	}
 
 	int64_t Hooks::PopulateTopicInfo(int64_t a_1, RE::TESTopic* a_2, RE::TESTopicInfo* a_3, RE::Character* a_speaker, RE::TESTopicInfo::ResponseData* a_5)


### PR DESCRIPTION

- Fix RefMap loading:
  - Revert the yaml-cpp target type from `vector<pair<string, string>>` to `map<string,string>` as yaml-cpp does not handle the former, resulting in always-empty RefMap
  - Change the yaml key back from `refs` to `refMap` as per wiki
- Failing to get the TESForm for the optional condition subject now raises a `runtime_error` instead of a mere log warning
- Logging changes to reduce clutter messages due to legal empty/zero fields, and outline the parsing process