### PR TITLE
Add "Target" keyword to run conditions on dialogue target

### DIFF
--- a/src/Dialogue/Conditions/ConditionParser.cpp
+++ b/src/Dialogue/Conditions/ConditionParser.cpp
@@ -98,7 +98,9 @@ RE::TESConditionItem* ConditionParser::Parse(std::string_view a_text, const RefM
 	}
 
 	if (!refStr.empty()) {
-		if (const auto ref = a_refMap.Lookup<RE::TESObjectREFR>(refStr)) {
+		if (Util::CastLower(refStr) == "target"s) {
+			data.object = RE::CONDITIONITEMOBJECT::kTarget;
+		} else if (const auto ref = a_refMap.Lookup<RE::TESObjectREFR>(refStr)) {
 			data.runOnRef = ref->CreateRefHandle();
 			data.object = RE::CONDITIONITEMOBJECT::kRef;
 		} else {


### PR DESCRIPTION
"Placeholder" PR to sticky this subject while you're away.
---
By default, conditions apply on the speaker (subject), unless a specific Ref is specified preceding `<>`.

Currently, if I'm not mistaken, there is no way to dynamically run conditions on the NPC when replacing Topics, since the speaker is always the player.

I'm pretty sure the subject and target references are appropriately passed around in `Hooks.cpp` and during condition evaluation, I think the problem really is semantic (isn't it?).

So here is a crude implementation of the following syntax:
```yaml
id: 0xdeadbeef|plugin.esp
text: "Bla"
conditions:
- Target <> CondFunction CondParam == 1
```
with the new special word `Target`. (can't be implemented via the RefMap as there is no fixed ref).

For completeness, to mirror the main CK options "Subject" and "Target", one could similarly add the special word `Subject` and setting `data.object = RE::CONDITIONITEMOBJECT::kSelf` instead. It is less critical since `kSelf` is default behavior, and one can write `Player` to get the target for TopicInfos. Maybe it would be useful for Scenes, though.

You probably want a cleaner implementation, in which case just close the PR.

---
CK screenshot showing what the CK allows:
![CK screenshot for reference](https://github.com/user-attachments/assets/7f7120ea-7632-4753-abab-687e2d2359a4)
